### PR TITLE
Fix registerPotionBrewing not working because it was a server script by making it a startup script

### DIFF
--- a/src/main/java/com/almostreliable/morejs/core/Events.java
+++ b/src/main/java/com/almostreliable/morejs/core/Events.java
@@ -35,6 +35,6 @@ public interface Events {
     EventHandler STRUCTURE_AFTER_PLACE = GROUP.server("structureAfterPlace", () -> StructureAfterPlaceEventJS.class);
     EventHandler XP_CHANGE = GROUP.server("playerXpChange", () -> ExperiencePlayerEventJS.class).hasResult();
     EventHandler PIGLIN_PLAYER_BEHAVIOR = GROUP.server("piglinPlayerBehavior", () -> PiglinPlayerBehaviorEventJS.class);
-    EventHandler POTION_BREWING_REGISTER = GROUP.server("registerPotionBrewing",
+    EventHandler POTION_BREWING_REGISTER = GROUP.startup("registerPotionBrewing",
             () -> PotionBrewingRegisterEvent.class);
 }


### PR DESCRIPTION
<!--
Before you submit anything:
  1. Make sure whatever you submit isn't already submitted or implemented in a newer version.
  2. Follow our Code of Conduct!
  3. Follow our Contribution Guidelines!

Steps to submit a pull request:
  1. Provide a short and clear title above.
  2. Split your pull request in logical commits especially if you implemented multiple features or fixed multiple bugs!
  3. Unrelated features or bug fixes should be done in different pull requests.
  4. Keep the submission in English.

If the pull request doesn't fulfill our guidelines, it will be closed without any comment.
-->

## Issue Reference
<!--
Is your pull request related to an issue?
If so, mention it here by providing the URL to the issue.
You can also provide multiple URLs if your pull request is related to multiple issues.
If not, you can delete this section.
-->

## Proposed Changes
<!--
Please give us a basic overview of your changes here. You can add sub-lists to add more description.
-->
- change registerPotionBrewing from server to startup
- fix registerPotionBrewing not working because it was changed to server in b40db9e418d0ca3f4b00afec1392032b0f8693c4

## Additional Context
<!--
If you have any additional material that might be valuable for this pull request such as screenshots, provide them here.
Otherwise delete this section.
-->

Tested with
```js
MoreJS.registerPotionBrewing(event => {
  event.removePotionBrewing({
    ingredient: 'minecraft:rabbit_foot'
  })
  
  event.addPotionBrewing("minecraft:acacia_log", "minecraft:harming")
})
```
in startup_scripts, it correctly removes the potion recipes using 'minecraft:rabbit_foot' as an ingredient and correctly adds the "minecraft:acacia_log" to "minecraft:harming" recipes.
<!-- 💚 Thank you for contributing! -->
